### PR TITLE
Use QEMU image in DigitalOcean documentation.

### DIFF
--- a/os/booting-on-digitalocean.md
+++ b/os/booting-on-digitalocean.md
@@ -2,7 +2,7 @@
 
 On Digital Ocean, users can upload Flatcar Container Linux as a [custom image](https://www.digitalocean.com/docs/images/custom-images/). Digital Ocean offers a [quick start guide](https://www.digitalocean.com/docs/images/custom-images/quickstart/) that walks you through the process.
 
-The _import URL_ should be `https://<channel>.release.flatcar-linux.net/amd64-usr/<version>/flatcar_production_digitalocean_image.bin.bz2`. See the [release page](https://www.flatcar-linux.org/releases/) for version and channel history.
+The _import URL_ should be `https://<channel>.release.flatcar-linux.net/amd64-usr/<version>/flatcar_production_qemu_image.img.bz2`. See the [release page](https://www.flatcar-linux.org/releases/) for version and channel history.
 
 The following command will create a single droplet. For more details, check out [Launching via the API](#via-the-api).
 


### PR DESCRIPTION
# Summary

Some of the current `flatcar_production_digitalocean_image.bin.bz2` images do not work (beta, alpha and edge). However all current `flatcar_production_qemu_image.img.bz2` variants do work.

# How to use

Some of the current `flatcar_production_digitalocean_image.bin.bz2` images do not work:
- ✅ https://stable.release.flatcar-linux.net/amd64-usr/2605.7.0/flatcar_production_digitalocean_image.bin.bz2
- ✅ https://beta.release.flatcar-linux.net/amd64-usr/2643.1.0/flatcar_production_digitalocean_image.bin.bz2
- ❌ https://alpha.release.flatcar-linux.net/amd64-usr/2671.0.0/flatcar_production_digitalocean_image.bin.bz2
- ❌ https://edge.release.flatcar-linux.net/amd64-usr/2666.99.0/flatcar_production_digitalocean_image.bin.bz2

The following error is being showed:

![Screenshot 2020-11-07 at 14 48 43](https://user-images.githubusercontent.com/1732671/98445194-8cca5700-2116-11eb-9b19-6f73d43f5847.png)

I'm able to download and decompress those failed images locally, rezipped, uploaded, but this also was not successful.

However the QEMU variants do work:

- ✅ https://stable.release.flatcar-linux.net/amd64-usr/2605.7.0/flatcar_production_qemu_image.img.bz2
- ✅ https://beta.release.flatcar-linux.net/amd64-usr/2643.1.0/flatcar_production_qemu_image.img.bz2
- ✅ https://alpha.release.flatcar-linux.net/amd64-usr/2671.0.0/flatcar_production_qemu_image.img.bz2
- ✅ https://edge.release.flatcar-linux.net/amd64-usr/2666.99.0/flatcar_production_qemu_image.img.bz2

# Testing done

- Created custom images via the web UI using the import URL function: https://cloud.digitalocean.com/images/custom_images
- Created 2GB droplets from the images which succeeded uploading
- Succesful SSH'd into the droplets
