### PR TITLE
cloud-providers/booting-on-virtualbox: fix branch names

### DIFF
--- a/docs/cloud-providers/booting-on-virtualbox.md
+++ b/docs/cloud-providers/booting-on-virtualbox.md
@@ -16,7 +16,7 @@ The script is located on [GitHub](https://github.com/flatcar-linux/scripts/blob/
 As first step, you must download the script and make it executable.
 
 ```shell
-wget https://raw.githubusercontent.com/flatcar-linux/scripts/flatcar-master/contrib/create-coreos-vdi
+wget https://raw.githubusercontent.com/flatcar-linux/scripts/main/contrib/create-coreos-vdi
 chmod +x create-coreos-vdi
 ```
 

--- a/docs/cloud-providers/booting-on-virtualbox.md
+++ b/docs/cloud-providers/booting-on-virtualbox.md
@@ -11,7 +11,7 @@ These instructions will walk you through running Flatcar Container Linux on Orac
 
 There is a script that simplifies building the VDI image. It downloads a bare-metal image, verifies it with GPG, and converts that image to a VDI image.
 
-The script is located on [GitHub](https://github.com/flatcar-linux/scripts/blob/flatcar-master/contrib/create-coreos-vdi). The running host must support VirtualBox tools.
+The script is located on [GitHub](https://github.com/flatcar-linux/scripts/blob/main/contrib/create-coreos-vdi). The running host must support VirtualBox tools.
 
 As first step, you must download the script and make it executable.
 

--- a/docs/cloud-providers/booting-on-virtualbox.md
+++ b/docs/cloud-providers/booting-on-virtualbox.md
@@ -11,12 +11,12 @@ These instructions will walk you through running Flatcar Container Linux on Orac
 
 There is a script that simplifies building the VDI image. It downloads a bare-metal image, verifies it with GPG, and converts that image to a VDI image.
 
-The script is located on [GitHub](https://github.com/flatcar-linux/scripts/blob/master/contrib/create-coreos-vdi). The running host must support VirtualBox tools.
+The script is located on [GitHub](https://github.com/flatcar-linux/scripts/blob/flatcar-master/contrib/create-coreos-vdi). The running host must support VirtualBox tools.
 
 As first step, you must download the script and make it executable.
 
 ```shell
-wget https://raw.githubusercontent.com/flatcar-linux/scripts/master/contrib/create-coreos-vdi
+wget https://raw.githubusercontent.com/flatcar-linux/scripts/flatcar-master/contrib/create-coreos-vdi
 chmod +x create-coreos-vdi
 ```
 
@@ -78,7 +78,7 @@ For more information on customization that can be done with cloud-config, head o
 You need a config-drive to configure at least one SSH key to access the virtual machine. If you are in hurry, you can create a basic config-drive with following steps:
 
 ```shell
-wget https://raw.github.com/flatcar-linux/scripts/master/contrib/create-basic-configdrive
+wget https://raw.github.com/flatcar-linux/scripts/flatcar-master/contrib/create-basic-configdrive
 chmod +x create-basic-configdrive
 ./create-basic-configdrive -H my_vm01 -S ~/.ssh/id_rsa.pub
 ```

--- a/docs/cloud-providers/booting-on-virtualbox.md
+++ b/docs/cloud-providers/booting-on-virtualbox.md
@@ -78,7 +78,7 @@ For more information on customization that can be done with cloud-config, head o
 You need a config-drive to configure at least one SSH key to access the virtual machine. If you are in hurry, you can create a basic config-drive with following steps:
 
 ```shell
-wget https://raw.github.com/flatcar-linux/scripts/flatcar-master/contrib/create-basic-configdrive
+wget https://raw.github.com/flatcar-linux/scripts/main/contrib/create-basic-configdrive
 chmod +x create-basic-configdrive
 ./create-basic-configdrive -H my_vm01 -S ~/.ssh/id_rsa.pub
 ```


### PR DESCRIPTION
Branch names of provisioning scripts were pointing to `.../master/...` instead of `.../flatcar-master/...`. The `master` branch is abandoned and contains outdated scripts with CoreOS URIs.