### PR TITLE
quickstart: link ignition docs coreos => kinvolk

### DIFF
--- a/docs/quickstart/_index.md
+++ b/docs/quickstart/_index.md
@@ -129,5 +129,5 @@ docker run -i -t busybox /bin/sh
 [ipxe-docs]: booting-with-ipxe
 [iso-docs]: booting-with-iso
 [install-docs]: installing-to-disk
-[ignition]: https://coreos.com/ignition/docs/latest/
+[ignition]: https://kinvolk.io/docs/flatcar-container-linux/latest/ignition/
 [cl-configs]: provisioning


### PR DESCRIPTION
Ignition docs link still pointed to coreos; updating to point to kinvolk.io/docs
