### PR TITLE
Fix missing markdown extension in external links

### DIFF
--- a/docs/bare-metal/installing-to-disk.md
+++ b/docs/bare-metal/installing-to-disk.md
@@ -148,4 +148,4 @@ Now that you have a machine booted it is time to play around. Check out the [Fla
 [clc-section]: #container-linux-configs
 [flatcar-install]: https://raw.githubusercontent.com/flatcar-linux/init/flatcar-master/bin/flatcar-install
 [cl-configs]: provisioning
-[ct]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/overview
+[ct]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/overview.md

--- a/docs/bare-metal/notes-for-distributors.md
+++ b/docs/bare-metal/notes-for-distributors.md
@@ -43,13 +43,13 @@ Use Ignition to handle platform specific configuration such as custom networking
 Additionally, it is recommended that providers ensure that [coreos-metadata][coreos-metadata] and [ct][ct] have support for their platform. This will allow a nicer user experience, as coreos-metadata will be able to install users' ssh keys and users will be able to reference dynamic data in their Container Linux Configs.
 
 [ignition]: https://coreos.com/blog/introducing-ignition.html
-[ign-platforms]: https://github.com/flatcar-linux/ignition/blob/master/doc/supported-platforms
+[ign-platforms]: https://github.com/flatcar-linux/ignition/blob/master/doc/supported-platforms.md
 [coreos-metadata]: https://github.com/flatcar-linux/coreos-metadata/
 [ct]: https://github.com/coreos/container-linux-config-transpiler
 
 ### Cloud config
 
-A Flatcar Container Linux image can also be customized using [cloud-config](https://github.com/flatcar-linux/coreos-cloudinit/blob/master/Documentation/cloud-config). Users are recommended to instead use Container Linux Configs (that are converted into Ignition configs with [ct][ct]), for reasons [outlined in the blog post that introduced Ignition][ignition].
+A Flatcar Container Linux image can also be customized using [cloud-config](https://github.com/flatcar-linux/coreos-cloudinit/blob/master/Documentation/cloud-config.md). Users are recommended to instead use Container Linux Configs (that are converted into Ignition configs with [ct][ct]), for reasons [outlined in the blog post that introduced Ignition][ignition].
 
 Providers that previously supported cloud-config should continue to do so, as not all users have switched over to Container Linux Configs. New platforms do not need to support cloud-config.
 
@@ -59,4 +59,4 @@ Flatcar Container Linux will automatically parse and execute `/usr/share/oem/clo
 
 End-users should be able to provide an Ignition file to your platform while specifying their VM's parameters. This file should be made available to Flatcar Container Linux at the time of boot (e.g. at known network address, injected directly onto disk). Examples of these data sources can be found in the [Ignition documentation][providers].
 
-[providers]: https://github.com/flatcar-linux/ignition/blob/master/doc/supported-platforms
+[providers]: https://github.com/flatcar-linux/ignition/blob/master/doc/supported-platforms.md

--- a/docs/cloud-providers/booting-on-virtualbox.md
+++ b/docs/cloud-providers/booting-on-virtualbox.md
@@ -69,11 +69,11 @@ coreos_production_stable.vdi
 
 ## Creating a config-drive
 
-Cloud-config can be specified by attaching a [config-drive](https://github.com/flatcar-linux/coreos-cloudinit/blob/master/Documentation/config-drive) with the label `config-2`. This is commonly done through whatever interface allows for attaching CD-ROMs or new drives.
+Cloud-config can be specified by attaching a [config-drive](https://github.com/flatcar-linux/coreos-cloudinit/blob/master/Documentation/config-drive.md) with the label `config-2`. This is commonly done through whatever interface allows for attaching CD-ROMs or new drives.
 
 Note that the config-drive standard was originally an OpenStack feature, which is why you'll see strings containing `openstack`. This filepath needs to be retained, although Flatcar Container Linux supports config-drive on all platforms.
 
-For more information on customization that can be done with cloud-config, head on over to the [cloud-config guide](https://github.com/flatcar-linux/coreos-cloudinit/blob/master/Documentation/cloud-config).
+For more information on customization that can be done with cloud-config, head on over to the [cloud-config guide](https://github.com/flatcar-linux/coreos-cloudinit/blob/master/Documentation/cloud-config.md).
 
 You need a config-drive to configure at least one SSH key to access the virtual machine. If you are in hurry, you can create a basic config-drive with following steps:
 

--- a/docs/cloud-providers/booting-on-vmware.md
+++ b/docs/cloud-providers/booting-on-vmware.md
@@ -152,7 +152,7 @@ On many cloud providers Ignition will run the [`coreos-metadata.service`](/ignit
 
 If you want to use dynamic data such as `{PRIVATE_IPV4}` and `{PUBLIC_IPV4}` in your Container Linux Config, you have to use the `--platform=custom` argument to the config transpiler and define your own `coreos-metadata.service`.
 
-In the following example we will use the [reserved variables](https://github.com/flatcar-linux/afterburn/blob/master/docs/container-linux-legacy) `COREOS_CUSTOM_PUBLIC_IPV4` and `COREOS_CUSTOM_PRIVATE_IPV4` known to the config transpiler so that Container Linux Configs which contain `{PUBLIC_IPV4}` in a systemd unit will use `${COREOS_CUSTOM_PUBLIC_IPV4}` instead by automatically sourcing it via `EnvironmentFile=/run/metadata/coreos`.
+In the following example we will use the [reserved variables](https://github.com/flatcar-linux/afterburn/blob/master/docs/container-linux-legacy.md) `COREOS_CUSTOM_PUBLIC_IPV4` and `COREOS_CUSTOM_PRIVATE_IPV4` known to the config transpiler so that Container Linux Configs which contain `{PUBLIC_IPV4}` in a systemd unit will use `${COREOS_CUSTOM_PUBLIC_IPV4}` instead by automatically sourcing it via `EnvironmentFile=/run/metadata/coreos`.
 
 ```yaml
 systemd:
@@ -188,7 +188,7 @@ For `$public_ipv4` and `$private_ipv4` substitutions to work you either need to 
 
 Besides applying the config itself `coreos-cloudinit` supports the `guestinfo.interface.*` variables and will generate a networkd unit from them stored in `/run/systemd/network/`.
 
-The guestinfo variables known to coreos-cloudinit are (taken from [here](https://github.com/flatcar-linux/coreos-cloudinit/blob/flatcar-master/Documentation/vmware-guestinfo#cloud-config-vmware-guestinfo-variables)), with `<n>`, `<m>`, `<l>` being numbers starting from 0:
+The guestinfo variables known to coreos-cloudinit are (taken from [here](https://github.com/flatcar-linux/coreos-cloudinit/blob/flatcar-master/Documentation/vmware-guestinfo.md#cloud-config-vmware-guestinfo-variables)), with `<n>`, `<m>`, `<l>` being numbers starting from 0:
 
 * `guestinfo.hostname` used for `hostnamectl set-hostname`
 * `guestinfo.interface.<n>.name` used in the `[Match]` section of the networkd unit (can include wildcards)

--- a/docs/clusters/creation/cluster-discovery.md
+++ b/docs/clusters/creation/cluster-discovery.md
@@ -134,8 +134,8 @@ The public discovery service is just an etcd cluster made available to the publi
 
 Since etcd is designed to this type of leader election, it was an obvious choice to use it for everyone's initial leader election. This means that it's easy to run your own etcd cluster for this purpose.
 
-If you're interested in how discovery API works behind the scenes in etcd, read about [etcd clustering](https://github.com/flatcar-linux/etcd/blob/master/Documentation/op-guide/clustering).
+If you're interested in how discovery API works behind the scenes in etcd, read about [etcd clustering](https://github.com/flatcar-linux/etcd/blob/master/Documentation/op-guide/clustering.md).
 
-[etcd-reconf]: https://github.com/flatcar-linux/etcd/blob/master/Documentation/op-guide/runtime-configuration
-[etcd-reconf-no-disc]: https://github.com/flatcar-linux/etcd/blob/master/Documentation/op-guide/runtime-reconf-design#do-not-use-public-discovery-service-for-runtime-reconfiguration
-[etcd-reconf-on-flatcar]: https://github.com/coreos/docs/blob/master/etcd/etcd-live-cluster-reconfiguration
+[etcd-reconf]: https://github.com/flatcar-linux/etcd/blob/master/Documentation/op-guide/runtime-configuration.md
+[etcd-reconf-no-disc]: https://github.com/flatcar-linux/etcd/blob/master/Documentation/op-guide/runtime-reconf-design.md#do-not-use-public-discovery-service-for-runtime-reconfiguration
+[etcd-reconf-on-flatcar]: https://github.com/coreos/docs/blob/master/etcd/etcd-live-cluster-reconfiguration.md

--- a/docs/clusters/customization/adding-users.md
+++ b/docs/clusters/customization/adding-users.md
@@ -7,7 +7,7 @@ You can create user accounts on a Flatcar Container Linux machine manually with 
 
 ## Add Users via Container Linux Configs
 
-In your Container Linux Config, you can specify many [different parameters](https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/configuration) for each user. Here's an example:
+In your Container Linux Config, you can specify many [different parameters](https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/configuration.md) for each user. Here's an example:
 
 ```yaml
 passwd:

--- a/docs/clusters/customization/using-environment-variables-in-systemd-units.md
+++ b/docs/clusters/customization/using-environment-variables-in-systemd-units.md
@@ -127,7 +127,7 @@ For more systemd examples, check out these documents:
 [cl-configs]: provisioning
 [etcd-discovery]: cluster-discovery
 [systemd-udev]: using-systemd-and-udev-rules
-[etcd-cluster-reconfiguration]: https://github.com/coreos/docs/blob/master/etcd/etcd-live-cluster-reconfiguration
+[etcd-cluster-reconfiguration]: https://github.com/coreos/docs/blob/master/etcd/etcd-live-cluster-reconfiguration.md
 
 ## More Information
 

--- a/docs/clusters/management/registry-authentication.md
+++ b/docs/clusters/management/registry-authentication.md
@@ -236,4 +236,4 @@ For details, check out the [Container Linux Config examples][ct-examples].
 [rfc-2397]: https://tools.ietf.org/html/rfc2397
 [rkt-config]: https://docs.flatcar-linux.org/os/registry-authentication/#rkt
 [cl-configs]: provisioning
-[ct-examples]: https://github.com/flatcar-linux/container-linux-config-transpiler/blob/flatcar-master/doc/examples
+[ct-examples]: https://github.com/flatcar-linux/container-linux-config-transpiler/blob/flatcar-master/doc/examples.md

--- a/docs/clusters/securing/adding-certificate-authorities.md
+++ b/docs/clusters/securing/adding-certificate-authorities.md
@@ -18,4 +18,4 @@ The setup process for any of these use-cases is the same:
 
 [Generate Self-Signed Certificates](generate-self-signed-certificates)
 
-[etcd Security Model](https://github.com/flatcar-linux/etcd/blob/master/Documentation/op-guide/security)
+[etcd Security Model](https://github.com/flatcar-linux/etcd/blob/master/Documentation/op-guide/security.md)

--- a/docs/community-platforms/booting-on-exoscale.md
+++ b/docs/community-platforms/booting-on-exoscale.md
@@ -14,7 +14,7 @@ The Exoscale Flatcar Container Linux image is built officially and each instance
 [reboot-docs]: update-strategies
 [switching-channels]: switching-channels
 [release-notes]: https://flatcar-linux.org/releases
-[cloud-config-docs]: https://github.com/flatcar-linux/coreos-cloudinit/blob/master/Documentation/cloud-config
+[cloud-config-docs]: https://github.com/flatcar-linux/coreos-cloudinit/blob/master/Documentation/cloud-config.md
 
 ## Security groups
 
@@ -83,7 +83,7 @@ To log in to a Flatcar Container Linux instance after it's created click on its 
 ssh core@<ip address>
 ```
 
-Optionally, you may want to [configure your ssh-agent](https://github.com/flatcar-linux/fleet/blob/master/Documentation/using-the-client#remote-fleet-access) to more easily run [fleet commands](../fleet/launching-containers-fleet).
+Optionally, you may want to [configure your ssh-agent](https://github.com/flatcar-linux/fleet/blob/master/Documentation/using-the-client.md#remote-fleet-access) to more easily run [fleet commands](../fleet/launching-containers-fleet).
 
 ## Launching instances
 

--- a/docs/community-platforms/booting-on-rackspace.md
+++ b/docs/community-platforms/booting-on-rackspace.md
@@ -73,7 +73,7 @@ flatcar:
 
 The `$private_ipv4` and `$public_ipv4` substitution variables are fully supported in cloud-config on Rackspace.
 
-[cloud-config-docs]: https://github.com/flatcar-linux/coreos-cloudinit/blob/master/Documentation/cloud-config
+[cloud-config-docs]: https://github.com/flatcar-linux/coreos-cloudinit/blob/master/Documentation/cloud-config.md
 
 ### Mount data disk
 

--- a/docs/community-platforms/booting-on-vultr.md
+++ b/docs/community-platforms/booting-on-vultr.md
@@ -31,9 +31,9 @@ sudo flatcar-install -d /dev/vda -c cloud-config.yaml
 sudo reboot
 ```
 
-Please be sure to check out [Using Cloud-Config](https://github.com/flatcar-linux/coreos-cloudinit/blob/master/Documentation/cloud-config).
+Please be sure to check out [Using Cloud-Config](https://github.com/flatcar-linux/coreos-cloudinit/blob/master/Documentation/cloud-config.md).
 
-You must add to your ssh public key to your `cloud-config`'s [ssh authorized keys](https://github.com/flatcar-linux/coreos-cloudinit/blob/master/Documentation/cloud-config#ssh_authorized_keys) so you'll be able to log in.
+You must add to your ssh public key to your `cloud-config`'s [ssh authorized keys](https://github.com/flatcar-linux/coreos-cloudinit/blob/master/Documentation/cloud-config.md#ssh_authorized_keys) so you'll be able to log in.
 
 ## Choosing a channel
 

--- a/docs/container-runtimes/generate-self-signed-certificates.md
+++ b/docs/container-runtimes/generate-self-signed-certificates.md
@@ -292,7 +292,7 @@ openssl x509 -in client.pem -text -noout
 For another examples, check out these documents:
 
 [Custom Certificate Authorities](adding-certificate-authorities)
-[etcd Security Model](https://github.com/flatcar-linux/etcd/blob/master/Documentation/op-guide/security)
+[etcd Security Model](https://github.com/flatcar-linux/etcd/blob/master/Documentation/op-guide/security.md)
 
 [cfssl]: https://github.com/cloudflare/cfssl
 [cfssl-bin]: https://pkg.cfssl.org

--- a/docs/contribute/docs.md
+++ b/docs/contribute/docs.md
@@ -210,11 +210,11 @@ which link will likewise have its label defined at the document's foot.
 
 Using relative URLs where possible helps portability among multiple presentation targets, as they remain valid even as the site root moves. Absolute linking is obviously necessary for resources external to the document's repository and/or the docs.flatcar-linux.org domain.
 
-For example, there are two ways to refer to the [CoreOS quick start guide][quickstart]'s location. The preferred way is a relative link from the current file's path to the target, which from this document is `os/quickstart`. An absolute link to the complete URL is less flexible, and more verbose: `https://github.com/flatcar-linux/docs/blob/master/os/quickstart`.
+For example, there are two ways to refer to the [CoreOS quick start guide][quickstart]'s location. The preferred way is a relative link from the current file's path to the target, which from this document is `os/quickstart`. An absolute link to the complete URL is less flexible, and more verbose: `https://github.com/flatcar-linux/docs/blob/master/os/quickstart.md`.
 
 #### Hyperlink deployment automation
 
-CoreOS documents have two major publication targets: the [docs.flatcar-linux.org documentation][flatcar-docs], and [GitHub's Markdown presentation][githubmd]. The deployment scripts used to build the CoreOS site handle some of the wrinkles arising between the two targets. These scripts expect links to other CoreOS project documentation to refer to the Markdown source; that is, to end with the `` file extension. The deployment scripts rewrite hyperlinks to replace that extension with `.html` for presentation. This allows the links to be valid in either context. External links are not rewritten.
+CoreOS documents have two major publication targets: the [docs.flatcar-linux.org documentation][flatcar-docs], and [GitHub's Markdown presentation][githubmd]. The deployment scripts used to build the CoreOS site handle some of the wrinkles arising between the two targets. These scripts expect links to other CoreOS project documentation to refer to the Markdown source; that is, to end with the `.md` file extension. The deployment scripts rewrite hyperlinks to replace that extension with `.html` for presentation. This allows the links to be valid in either context. External links are not rewritten.
 
 ## Example: Documenting code blocks
 

--- a/docs/ignition/_index.md
+++ b/docs/ignition/_index.md
@@ -46,7 +46,7 @@ The [full list of supported platforms][supported-platforms] is provided and will
 
 Ignition is under active development. Expect to see support for more images in the coming months.
 
-[examples]: https://github.com/flatcar-linux/ignition/blob/flatcar-master/doc/examples.d
+[examples]: https://github.com/flatcar-linux/ignition/blob/flatcar-master/doc/examples.md
 [cloudinit]: https://github.com/flatcar-linux/coreos-cloudinit
 [network-config]: network-configuration
 [custom-agent]: https://github.com/flatcar-linux/ignition/blob/flatcar-master/doc/examples.md#custom-metadata-agent

--- a/docs/ignition/_index.md
+++ b/docs/ignition/_index.md
@@ -46,10 +46,10 @@ The [full list of supported platforms][supported-platforms] is provided and will
 
 Ignition is under active development. Expect to see support for more images in the coming months.
 
-[examples]: https://github.com/flatcar-linux/ignition/blob/flatcar-master/doc/examples
+[examples]: https://github.com/flatcar-linux/ignition/blob/flatcar-master/doc/examples.d
 [cloudinit]: https://github.com/flatcar-linux/coreos-cloudinit
 [network-config]: network-configuration
-[custom-agent]: https://github.com/flatcar-linux/ignition/blob/flatcar-master/doc/examples#custom-metadata-agent
-[supported-platforms]: https://github.com/flatcar-linux/ignition/blob/flatcar-master/doc/supported-platforms
+[custom-agent]: https://github.com/flatcar-linux/ignition/blob/flatcar-master/doc/examples.md#custom-metadata-agent
+[supported-platforms]: https://github.com/flatcar-linux/ignition/blob/flatcar-master/doc/supported-platforms.md
 [systemd-generator]: http://www.freedesktop.org/software/systemd/man/systemd.generator.html
 [initramfs]: https://www.kernel.org/doc/Documentation/filesystems/ramfs-rootfs-initramfs.txt

--- a/docs/ignition/metadata.md
+++ b/docs/ignition/metadata.md
@@ -81,4 +81,4 @@ ExecStart=/usr/bin/bash -c 'echo "CUSTOM_EC2_IPV4_PUBLIC=$(curl\
 ```
 
 
-[metadata-docs]: https://github.com/flatcar-linux/afterburn/blob/master/docs/container-linux-legacy
+[metadata-docs]: https://github.com/flatcar-linux/afterburn/blob/master/docs/container-linux-legacy.md

--- a/docs/quickstart/_index.md
+++ b/docs/quickstart/_index.md
@@ -42,7 +42,7 @@ Flatcar Container Linux (beta)
 
 The first building block of Flatcar Container Linux is service discovery with **etcd** ([docs][etcd-docs]). Data stored in etcd is distributed across all of your machines running Flatcar Container Linux. For example, each of your app containers can announce itself to a proxy container, which would automatically know which machines should receive traffic. Building service discovery into your application allows you to add more machines and scale your services seamlessly.
 
-If you used an example [Container Linux Config][cl-configs] or [cloud-config](https://github.com/flatcar-linux/coreos-cloudinit/blob/master/Documentation/cloud-config) from a guide linked in the first paragraph, etcd is automatically started on boot.
+If you used an example [Container Linux Config][cl-configs] or [cloud-config](https://github.com/flatcar-linux/coreos-cloudinit/blob/master/Documentation/cloud-config.md) from a guide linked in the first paragraph, etcd is automatically started on boot.
 
 A good starting point for a Container Linux Config would be something like:
 

--- a/docs/reference/developer-guides/_index.md
+++ b/docs/reference/developer-guides/_index.md
@@ -17,4 +17,4 @@ Most users will never have to build Flatcar Container Linux from source or modif
 [production-images]: sdk-building-production-images
 [mod-cl]: sdk-modifying-flatcar
 [kernel-modules]: kernel-modules
-[mantle-utils]: https://github.com/flatcar-linux/mantle/blob/master/README#kola
+[mantle-utils]: https://github.com/flatcar-linux/mantle/blob/master/README.md#kola

--- a/docs/reference/developer-guides/sdk-tips-and-tricks.md
+++ b/docs/reference/developer-guides/sdk-tips-and-tricks.md
@@ -104,7 +104,7 @@ The new package will now be built and installed as part of the normal build flow
 
 If tests are successful, commit the changes, push to your GitHub fork and create a pull request.
 
-[CONTRIBUTING]: https://github.com/flatcar-linux/etcd/blob/master/CONTRIBUTING
+[CONTRIBUTING]: https://github.com/flatcar-linux/etcd/blob/master/CONTRIBUTING.md
 
 ### Packaging references
 

--- a/docs/reference/migrating-to-clcs/_index.md
+++ b/docs/reference/migrating-to-clcs/_index.md
@@ -339,6 +339,6 @@ storage:
 ```
 
 [provisioning]: provisioning
-[dynamic-data]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/dynamic-data
-[ct-config]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/configuration
+[dynamic-data]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/dynamic-data.md
+[ct-config]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/configuration.md
 [ignition]: https://coreos.com/ignition

--- a/docs/reference/migrating-to-clcs/provisioning.md
+++ b/docs/reference/migrating-to-clcs/provisioning.md
@@ -132,17 +132,17 @@ For a [number of reasons][vs], coreos-cloudinit has been deprecated in favor of 
 
 Now that the basics of Container Linux Configs have been covered, a good next step is to read through the [examples][examples] and start experimenting. The [troubleshooting guide][troubleshooting] is a good reference for debugging issues.
 
-[clc]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/configuration
+[clc]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/configuration.md
 [cloudinit]: https://github.com/flatcar-linux/coreos-cloudinit
-[ct]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/overview
+[ct]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/overview.md
 [download-ct]: https://github.com/coreos/container-linux-config-transpiler/releases
 [etcd]: https://github.com/flatcar-linux/etcd
-[examples]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/examples
+[examples]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/examples.md
 [flannel]: https://github.com/coreos/flannel
 [locksmith]: https://github.com/flatcar-linux/locksmith
 [matchbox]: https://github.com/coreos/matchbox
 [metadata]: ../ignition/metadata
 [migrating]: migrating-to-clcs
 [rkt]: https://github.com/rkt/rkt
-[troubleshooting]: https://github.com/flatcar-linux/ignition/blob/master/doc/getting-started#troubleshooting
+[troubleshooting]: https://github.com/flatcar-linux/ignition/blob/master/doc/getting-started.md#troubleshooting
 [vs]: ../ignition/what-is-ignition#ignition-vs-coreos-cloudinit


### PR DESCRIPTION

# Revert broken external markdown links

External links containing markdown extension were broken during refactoring done at ee10233 (#124).

# How to use

N/A

# Testing done

- Ensured the changed links are now working
- All changed links in ee10233 that are matching `\w+:\/\/.+\.md` were reverted