### PR TITLE
docs: update cork to 0.15.2, remove gpg key

### DIFF
--- a/docs/reference/developer-guides/sdk-modifying-flatcar.md
+++ b/docs/reference/developer-guides/sdk-modifying-flatcar.md
@@ -39,9 +39,8 @@ The `cork` utility, included in the Flatcar Container Linux [mantle](https://git
 First, download the cork utility and verify it with the signature:
 
 ```shell
-curl -L -o cork https://github.com/flatcar-linux/mantle/releases/download/v0.15.1/cork-0.15.1-amd64
-curl -L -o cork.sig https://github.com/flatcar-linux/mantle/releases/download/v0.15.1/cork-0.15.1-amd64.sig
-gpg --receive-keys 84C8E771C0DF83DFBFCAAAF03ADA89DEC2507883
+curl -L -o cork https://github.com/kinvolk/mantle/releases/download/v0.15.2/cork-0.15.2-amd64
+curl -L -o cork.sig https://github.com/kinvolk/mantle/releases/download/v0.15.2/cork-0.15.2-amd64.sig
 curl -LO https://www.flatcar-linux.org/security/image-signing-key/Flatcar_Image_Signing_Key.asc
 gpg --import Flatcar_Image_Signing_Key.asc
 rm Flatcar_Image_Signing_Key.asc


### PR DESCRIPTION
Update the cork version to 0.15.2, to fix recent bugs around `repo init` commands.

Also change the github org name to `kinvolk`.

Also remove unnecessary commands for receiving a gpg key, because the cork binary file is now signed with the image build signing key.
