### PR TITLE
Add docs for Flatcar Pro on Azure

### DIFF
--- a/docs/installing/cloud/azure.md
+++ b/docs/installing/cloud/azure.md
@@ -114,6 +114,12 @@ $ az vm create --name node-1 --resource-group group-1 --admin-username core --cu
   </div>
 </div>
 
+### Flatcar Pro Images
+
+Flatcar Pro images in the marketplace are paid images and come with commercial support and extra features. They are published for the Stable and Beta channels. The Pro image for Azure has support for NVidia GPUs.
+
+Using the Azure CLI you can list the Pro images for, e.g., the Stable channel, with `az vm image list --all -p kinvolk -f flatcar_pro -s stable`.
+
 ## Uploading your own Image
 
 To automatically download the Flatcar image for Azure from the release page and upload it to your Azure account, run the following command:

--- a/docs/installing/cloud/azure.md
+++ b/docs/installing/cloud/azure.md
@@ -172,7 +172,7 @@ via a Container Linux Config. Head over to the [provisioning docs][cl-configs] t
 Note that Microsoft Azure doesn't allow an instance's userdata to be modified after the instance had been launched. This
 isn't a problem since Ignition, the tool that consumes the userdata, only runs on the first boot.
 
-You can provide a raw Ignition config (produced from a Container Linux Config) to Flatcar Container Linux via the Azure CLI using the `----custom-data` flag.
+You can provide a raw Ignition config (produced from a Container Linux Config) to Flatcar Container Linux via the Azure CLI using the `--custom-data` flag.
 
 As an example, the following config will configure and start etcd:
 


### PR DESCRIPTION
This documents the Flatcar Pro marketplace images and how to query them
    from the CLI. Currently the latest release does not support the GPU
    drivers and an old version has to be used, this is documented as well.

