### PR TITLE
Using a custom Docker version

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -80,6 +80,7 @@ Docker |
 -------------- |
 [Getting started with Docker][docker] |
 [Customizing Docker][customizing-docker] |
+[Use a custom Docker or containerd version][use-a-custom-docker-or-containerd-version] |
 [Switching from Docker to containerd for Kubernetes][containerd-for-kubernetes] |
 
 ### Reference
@@ -158,6 +159,7 @@ APIs and troubleshooting guides for working with Flatcar Container Linux.
 [container-linux-rollbacks]: clusters/debug/manual-rollbacks
 [docker]: container-runtimes/getting-started-with-docker
 [customizing-docker]: container-runtimes/customizing-docker
+[use-a-custom-docker-or-containerd-version]: container-runtimes/use-a-custom-docker-or-containerd-version
 [developer-guides]: reference/developer-guides/
 [integrations]: reference/integrations/
 [migrating-from-cloud-config]: reference/migrating-to-clcs/

--- a/docs/container-runtimes/customizing-docker.md
+++ b/docs/container-runtimes/customizing-docker.md
@@ -1,5 +1,5 @@
 ---
-title: Customizing docker
+title: Customizing Docker
 weight: 10
 ---
 

--- a/docs/container-runtimes/customizing-docker.md
+++ b/docs/container-runtimes/customizing-docker.md
@@ -5,6 +5,8 @@ weight: 10
 
 The Docker systemd unit can be customized by overriding the unit that ships with the default Flatcar Container Linux settings or through a drop-in unit. Common use-cases for doing this are covered below.
 
+For switching to using containerd with Kubernetes, there is an [extra guide](../switching-from-docker-to-containerd-for-kubernetes/).
+
 ## Use a custom containerd configuration
 
 The default configuration under `/run/torcx/unpack/docker/usr/share/containerd/config.toml` can't be changed but you can copy it to `/etc/containerd/config.toml` and modify it.

--- a/docs/container-runtimes/customizing-docker.md
+++ b/docs/container-runtimes/customizing-docker.md
@@ -3,7 +3,21 @@ title: Customizing Docker
 weight: 10
 ---
 
-The Docker systemd unit can be customized by overriding the unit that ships with the default Flatcar Container Linux settings. Common use-cases for doing this are covered below.
+The Docker systemd unit can be customized by overriding the unit that ships with the default Flatcar Container Linux settings or through a drop-in unit. Common use-cases for doing this are covered below.
+
+## Use a custom containerd configuration
+
+The default configuration under `/run/torcx/unpack/docker/usr/share/containerd/config.toml` can't be changed but you can copy it to `/etc/containerd/config.toml` and modify it.
+Then create a `/etc/systemd/system/containerd.service.d/10-use-custom-config.conf` unit drop-in file to select the new configuration:
+
+```ini
+[Service]
+Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
+ExecStart=
+ExecStart=/usr/bin/env PATH=${TORCX_BINDIR}:${PATH} ${TORCX_BINDIR}/containerd --config ${CONTAINERD_CONFIG}
+```
+
+On a running system, execute `systemctl daemon-reload ; systemctl restart containerd` for it to take effect.
 
 ## Enable the remote API on a new socket
 

--- a/docs/container-runtimes/use-a-custom-docker-or-containerd-version.md
+++ b/docs/container-runtimes/use-a-custom-docker-or-containerd-version.md
@@ -1,0 +1,151 @@
+---
+title: Use a custom Docker or containerd version
+weight: 10
+---
+
+Some system tooling can't be run on Container Linux via containers and this is especially true for the container runtime itself.
+As with other special binaries you want to bring to the system you can use an Ignition config that downloads the binaries.
+
+For custom Docker binaries you can consider to use the [Torcx](../../torcx/) addon manager when you build your own Torcx image and profile.
+However, since the Torcx makes certain assumtions about the files being shipped you may find it too limiting (e.g., the wrapper scripts under `/usr/bin/` exist for only a fixed set of binaries).
+In this case you can directly place the custom binaries to `/opt/bin/` as done by the following Container Linux Config which you can transpile to an Ignition config with [`ct`](../../container-linux-config-transpiler/).
+
+This replicates the Docker setup as of Flatcar Container Linux 2605.9.0 but under `/etc` and `/opt/bin/`. You can modify it to use different socket paths or plugins, or even only ship `containerd` if you don't need Docker.
+
+```
+systemd:
+  units:
+    - name: prepare-docker.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Unpack docker binaries to /opt/bin
+        ConditionPathExists=!/opt/bin/docker
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        Restart=on-failure
+        ExecStartPre=/usr/bin/mkdir -p /opt/bin
+        ExecStartPre=/usr/bin/tar -v --extract --file /opt/docker.tgz --directory /opt/ --no-same-owner
+        ExecStartPre=/usr/bin/rm /opt/docker.tgz
+        ExecStartPre=/usr/bin/sh -c "mv /opt/docker/* /opt/bin/"
+        ExecStart=/usr/bin/rmdir /opt/docker
+        [Install]
+        WantedBy=multi-user.target
+    - name: docker.socket
+      enabled: true
+      contents: |
+        [Unit]
+        PartOf=docker.service
+        Description=Docker Socket for the API
+        [Socket]
+        ListenStream=/var/run/docker.sock
+        SocketMode=0660
+        SocketUser=root
+        SocketGroup=docker
+        [Install]
+        WantedBy=sockets.target
+    - name: docker.service
+      enabled: false
+      contents: |
+        [Unit]
+        Description=Docker Application Container Engine
+        After=containerd.service docker.socket network-online.target prepare-docker.service
+        Wants=network-online.target
+        Requires=containerd.service docker.socket prepare-docker.service
+        [Service]
+        Type=notify
+        EnvironmentFile=-/run/flannel/flannel_docker_opts.env
+        Environment=DOCKER_SELINUX=--selinux-enabled=true
+        # the default is not to use systemd for cgroups because the delegate issues still
+        # exists and systemd currently does not support the cgroup feature set required
+        # for containers run by docker
+        Environment=PATH=/opt/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+        ExecStart=/opt/bin/dockerd --host=fd:// --containerd=/run/containerd/containerd.sock $DOCKER_SELINUX $DOCKER_OPTS $DOCKER_CGROUPS $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ
+        ExecReload=/bin/kill -s HUP $MAINPID
+        LimitNOFILE=1048576
+        # Having non-zero Limit*s causes performance problems due to accounting overhead
+        # in the kernel. We recommend using cgroups to do container-local accounting.
+        LimitNPROC=infinity
+        LimitCORE=infinity
+        # Uncomment TasksMax if your systemd version supports it.
+        # Only systemd 226 and above support this version.
+        TasksMax=infinity
+        TimeoutStartSec=0
+        # set delegate yes so that systemd does not reset the cgroups of docker containers
+        Delegate=yes
+        # kill only the docker process, not all processes in the cgroup
+        KillMode=process
+        # restart the docker process if it exits prematurely
+        Restart=on-failure
+        StartLimitBurst=3
+        StartLimitInterval=60s
+        [Install]
+        WantedBy=multi-user.target
+    - name: containerd.service
+      enabled: false
+      contents: |
+        [Unit]
+        Description=containerd container runtime
+        After=network.target prepare-docker.service
+        Requires=prepare-docker.service
+        [Service]
+        Delegate=yes
+        Environment=PATH=/opt/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+        ExecStart=/opt/bin/containerd --config /etc/containerd/config.toml
+        KillMode=process
+        Restart=always
+        # (lack of) limits from the upstream docker service unit
+        LimitNOFILE=1048576
+        LimitNPROC=infinity
+        LimitCORE=infinity
+        TasksMax=infinity
+        [Install]
+        WantedBy=multi-user.target
+storage:
+  files:
+    - path: /opt/docker.tgz
+      filesystem: root
+      mode: 0644
+      contents:
+        remote:
+          url: https://download.docker.com/linux/static/stable/x86_64/docker-19.03.14.tgz
+    - path: /etc/containerd/config.toml
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          # persistent data location
+          root = "/var/lib/containerd"
+          # runtime state information
+          state = "/run/docker/libcontainerd/containerd"
+          # set containerd as a subreaper on linux when it is not running as PID 1
+          subreaper = true
+          # set containerd's OOM score
+          oom_score = -999
+          # CRI plugin listens on a TCP port by default
+          disabled_plugins = ["cri"]
+          # grpc configuration
+          [grpc]
+          address = "/run/docker/libcontainerd/docker-containerd.sock"
+          # socket uid
+          uid = 0
+          # socket gid
+          gid = 0
+          [plugins.linux]
+          # shim binary name/path
+          shim = "containerd-shim"
+          # runtime binary name/path
+          runtime = "runc"
+          # do not use a shim when starting containers, saves on memory but
+          # live restore is not supported
+          no_shim = false
+          # display shim logs in the containerd daemon's log output
+          shim_debug = true
+```
+
+While the system services have a `PATH` variable that prefers `/opt/bin/` by placing it first, you have to run the following command on every interactive login shell (also after `sudo` or `su`) to make sure you use the correct binaries.
+
+```sh
+export PATH="/opt/bin:$PATH"
+```


### PR DESCRIPTION
- Add new docs on deploying a custom Docker version through Ignition
    Even though Torcx exists for some time already, it's not really
    accessible and has several flaws. Therefore, users tend to prefer to
    provisioning custom binaries through Ignition but there are no docs
    yet about this.
    Document how to replicate the Docker setup Flatcar has by writing new
    files to /etc and /opt/bin as a starting point for users to do their
    customizations, like just downloading containerd or additional tools.
- customizing-docker: Show how to use a custom containerd configuration
- docs/container-runtimes/customizing-docker.md: Capital D for Docker

# How to use/testing done

Save the config file and convert it: `cat config.yaml | container-linux-config-transpiler/bin/ct > config.json`
Start a VM: `./flatcar_production_qemu.sh -i config.json`
Log in: `ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 core@127.0.0.1`, then run the `export` command stated there and check that Docker works.

