### PR TITLE
use-a-custom-docker-or-containerd-version.md: Fix inconsistent path

### DIFF
--- a/docs/container-runtimes/use-a-custom-docker-or-containerd-version.md
+++ b/docs/container-runtimes/use-a-custom-docker-or-containerd-version.md
@@ -61,7 +61,7 @@ systemd:
         # exists and systemd currently does not support the cgroup feature set required
         # for containers run by docker
         Environment=PATH=/opt/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
-        ExecStart=/opt/bin/dockerd --host=fd:// --containerd=/run/containerd/containerd.sock $DOCKER_SELINUX $DOCKER_OPTS $DOCKER_CGROUPS $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ
+        ExecStart=/opt/bin/dockerd --host=fd:// --containerd=/run/docker/libcontainerd/docker-containerd.sock $DOCKER_SELINUX $DOCKER_OPTS $DOCKER_CGROUPS $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ
         ExecReload=/bin/kill -s HUP $MAINPID
         LimitNOFILE=1048576
         # Having non-zero Limit*s causes performance problems due to accounting overhead


### PR DESCRIPTION
When writing the docs I considered using the default containerd socket
but then switched back to what we use in Flatcar. However, I forgot to
do it in the dockerd argument.

# How to use/testing done
I reran the test and verified that Docker runs as expected and uses the correct socket path.