### PR TITLE
Document Terraform usage

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -24,6 +24,7 @@ Provisioning                                                                    
 [CL Config Dynamic Metadata][config-dynamic-data], [Ignition Dynamic Metadata][ignition-metadata] | [Packet][packet]
 [CL ct][config-intro], [CL Config Examples][config-examples]                                      | [QEMU][qemu], [libVirt][libvirt], [VirtualBox][virtualbox]¹, [Vagrant][vagrant]¹
 [CL Config Spec][config-spec], [CL Config Notes][config-notes]                                    | [VMware][vmware]
+[Terraform][terraform]                                                                            | [Hetzner][hetzner]
 
 _¹ These platforms are not officially supported and releases are not tested._
 
@@ -164,3 +165,5 @@ APIs and troubleshooting guides for working with Flatcar Container Linux.
 [integrations]: reference/integrations/
 [migrating-from-cloud-config]: reference/migrating-to-clcs/
 [containerd-for-kubernetes]: container-runtimes/switching-from-docker-to-containerd-for-kubernetes
+[terraform]: terraform/
+[hetzner]: cloud-providers/booting-on-hetzner

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -21,7 +21,7 @@ Provisioning                                                                    
 [Ignition vs coreos-cloudinit][ignition-what], [Boot Process][ignition-boot]                      | [DigitalOcean][digital-ocean]
 [Ignition Network Config][ignition-network]                                                       | [Google Compute Engine][gce]
 [Container Linux Config Transpiler][config-transpiler]                                            | [Microsoft Azure][azure]
-[CL Config Dynamic Metadata][config-dynamic-data], [Ignition Dynamic Metadata][ignition-metadata] | [Packet][packet]
+[CL Config Dynamic Metadata][config-dynamic-data], [Ignition Dynamic Metadata][ignition-metadata] | [Equinix Metal][equinix-metal]
 [CL ct][config-intro], [CL Config Examples][config-examples]                                      | [QEMU][qemu], [libVirt][libvirt], [VirtualBox][virtualbox]¹, [Vagrant][vagrant]¹
 [CL Config Spec][config-spec], [CL Config Notes][config-notes]                                    | [VMware][vmware]
 [Terraform][terraform]                                                                            | [Hetzner][hetzner]
@@ -118,7 +118,7 @@ APIs and troubleshooting guides for working with Flatcar Container Linux.
 [gce]: cloud-providers/booting-on-google-compute-engine
 [azure]: cloud-providers/booting-on-azure
 [qemu]: cloud-providers/booting-with-qemu
-[packet]: cloud-providers/booting-on-packet
+[equinix-metal]: cloud-providers/booting-on-packet
 [libvirt]: cloud-providers/booting-with-libvirt
 [virtualbox]: cloud-providers/booting-on-virtualbox
 [vagrant]: cloud-providers/booting-on-vagrant

--- a/docs/cloud-providers/booting-on-hetzner.md
+++ b/docs/cloud-providers/booting-on-hetzner.md
@@ -1,0 +1,208 @@
+---
+title: Running Flatcar Container Linux on Hetzner
+linktitle: Running on Hetzner
+weight: 10
+---
+
+[Hetzner Cloud](https://www.hetzner.com/cloud) is a cloud hosting provider.
+Flatcar Container Linux is not installable as one of the default operating system options but you can deploy it by installing it through the rescue OS.
+At the end of the document there are instructions for deploying with Terraform.
+
+## Preparations
+
+Register your SSH key in the Hetzner web interface to be able to log in to a machine.
+
+For programatic access, create an API token (e.g., used with Terraform as `HCLOUD_TOKEN` environment variable).
+
+## Provisioning
+
+Select any OS like Debian when you create the instance but boot into the `linux64` rescue OS.
+Connect via SSH and download and run the `flatcar-install` script:
+
+```sh
+curl -fsSLO --retry-delay 1 --retry 60 --retry-connrefused --retry-max-time 60 --connect-timeout 20 https://raw.githubusercontent.com/kinvolk/init/flatcar-master/bin/flatcar-install
+chmod +x flatcar-install
+./flatcar-install -s -i ignition.json # optional: you may provide a Ignition Config as file, it should contain your SSH key
+shutdown -r +1 # reboot into Flatcar
+```
+
+## Terraform
+
+The [`hcloud`](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs) Terraform Provider allows to deploy machines in a declarative way.
+Read more about using Terraform and Flatcar [here](../../terraform/).
+
+The following Terraform v0.13 module may serve as a base for your own setup.
+It will also take care of registering your SSH key at Hetzner.
+
+Start with a `hetzner-machines.tf` file that contains the main declarations:
+
+```
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = "1.23.0"
+    }
+    ct = {
+      source  = "poseidon/ct"
+      version = "0.7.1"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = "~> 2.2.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0.0"
+    }
+  }
+}
+
+resource "hcloud_ssh_key" "first" {
+  name       = var.cluster_name
+  public_key = var.ssh_keys.0
+}
+
+resource "hcloud_server" "machine" {
+  for_each = toset(var.machines)
+  name     = "${var.cluster_name}-${each.key}"
+  ssh_keys = [hcloud_ssh_key.first.id]
+  # boot into rescue OS
+  rescue = "linux64"
+  # dummy value for the OS because Flatcar is not available
+  image       = "debian-9"
+  server_type = var.server_type
+  datacenter  = var.datacenter
+  connection {
+    host    = self.ipv4_address
+    timeout = "1m"
+  }
+  provisioner "file" {
+    content     = data.ct_config.machine-ignitions[each.key].rendered
+    destination = "/root/ignition.json"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "set -ex",
+      "curl -fsSLO --retry-delay 1 --retry 60 --retry-connrefused --retry-max-time 60 --connect-timeout 20 https://raw.githubusercontent.com/kinvolk/init/flatcar-master/bin/flatcar-install",
+      "chmod +x flatcar-install",
+      "./flatcar-install -s -i /root/ignition.json",
+      "shutdown -r +1",
+    ]
+  }
+
+  # optional:
+  provisioner "remote-exec" {
+    connection {
+      host    = self.ipv4_address
+      timeout = "3m"
+      user    = "core"
+    }
+
+    inline = [
+      "sudo hostnamectl set-hostname ${self.name}",
+    ]
+  }
+}
+
+data "ct_config" "machine-ignitions" {
+  for_each = toset(var.machines)
+  content  = data.template_file.machine-configs[each.key].rendered
+}
+
+data "template_file" "machine-configs" {
+  for_each = toset(var.machines)
+  template = file("${path.module}/machine-${each.key}.yaml.tmpl")
+
+  vars = {
+    ssh_keys = jsonencode(var.ssh_keys)
+    name     = each.key
+  }
+}
+```
+
+Create a `variables.tf` file that declares the variables used above:
+
+```
+variable "machines" {
+  type        = list(string)
+  description = "Machine names, corresponding to machine-NAME.yaml.tmpl files"
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "Cluster name used as prefix for the machine names"
+}
+
+variable "ssh_keys" {
+  type        = list(string)
+  description = "SSH public keys for user 'core' and to register on Hetzner Cloud"
+}
+
+variable "server_type" {
+  type        = string
+  default     = "cx11"
+  description = "The server type to rent"
+}
+
+variable "datacenter" {
+  type        = string
+  description = "The region to deploy in"
+}
+```
+
+An `outputs.tf` file shows the resulting IP addresses:
+
+```
+output "ip-addresses" {
+  value = {
+    for key in var.machines :
+    "${var.cluster_name}-${key}" => hcloud_server.machine[key].ipv4_address
+  }
+}
+```
+
+Now you can use the module by declaring the variables and a Container Linux Configuration for a machine.
+First create a `terraform.tfvars` file with your settings:
+
+```
+cluster_name = "mycluster"
+machines     = ["mynode"]
+datacenter   = "fsn1-dc14"
+ssh_keys     = ["ssh-rsa AA... me@mail.net"]
+```
+
+Create the configuration for `mynode` in the file `machine-mynode.yaml.tmpl`:
+
+```yaml
+---
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys: ${ssh_keys}
+storage:
+  files:
+    - path: /home/core/works
+      filesystem: root
+      mode: 0755
+      contents:
+        inline: |
+          #!/bin/bash
+          set -euo pipefail
+          hostname="$(hostname)"
+          echo My name is ${name} and the hostname is $${hostname}
+```
+
+Finally, run Terraform v0.13 as follows to create the machine:
+
+```
+export HCLOUD_TOKEN=...
+terraform init
+terraform apply
+```
+
+Log in via `ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null core@IPADDRESS` with the printed IP address.
+
+When you make a change to `machine-mynode.yaml.tmpl` and run `terraform apply` again, the machine will be replaced.

--- a/docs/cloud-providers/booting-on-packet.md
+++ b/docs/cloud-providers/booting-on-packet.md
@@ -1,18 +1,18 @@
 ---
-title: Running Flatcar Container Linux on Packet
-linktitle: Running on Packet
+title: Running Flatcar Container Linux on Equinix Metal
+linktitle: Running on Equinix Metal
 weight: 10
 ---
 
-Packet is a bare metal cloud hosting provider. Flatcar Container Linux is installable as one of the default operating system options. You can deploy Flatcar Container Linux servers via the Packet portal or API. At the end of the document there are instructions for deploying with Terraform.
+Equinix Metal (formerly known as Packet) is a bare metal cloud hosting provider. Flatcar Container Linux is installable as one of the default operating system options. You can deploy Flatcar Container Linux servers via the web portal or API. At the end of the document there are instructions for deploying with Terraform.
 
 ## Deployment instructions
 
-The first step in deploying any devices on Packet is to first create an account and decide if you'd like to deploy via our portal or API. The portal is appropriate for small clusters of machines that won't change frequently. If you'll be deploying a lot of machines, or expect your workload to change frequently it is much more efficient to use the API. You can generate an API token through the portal once you've set up an account and payment method.
+The first step in deploying any devices on Equinix Metal is to first create an account and decide if you'd like to deploy via our portal or API. The portal is appropriate for small clusters of machines that won't change frequently. If you'll be deploying a lot of machines, or expect your workload to change frequently it is much more efficient to use the API. You can generate an API token through the portal once you've set up an account and payment method.
 
 ### Projects
 
-Packet has a concept of 'projects' that represent a grouping of machines that defines several other aspects of the service. A project defines who on the team has access to manage the machines in your account. Projects also define your private network; all machines in a given project will automatically share backend network connectivity. The SSH keys of all team members associated with a project will be installed to all newly provisioned machines in a project. All servers need to be in a project, even if there is only one server in that project.
+Equinix Metal has a concept of 'projects' that represent a grouping of machines that defines several other aspects of the service. A project defines who on the team has access to manage the machines in your account. Projects also define your private network; all machines in a given project will automatically share backend network connectivity. The SSH keys of all team members associated with a project will be installed to all newly provisioned machines in a project. All servers need to be in a project, even if there is only one server in that project.
 
 ### Portal instructions
 
@@ -20,7 +20,7 @@ Once logged into the portal you will be able to click the 'New server' button an
 
 ### API instructions
 
-If you select to use the API to provision machines on Packet you should consider using [one of the language libraries](https://www.packet.com/developers/libraries/) to code against. As an example, this is how you would launch a single Type 1 machine in a curl command. [Packet API Documentation](https://www.packet.com/developers/api/).
+If you select to use the API to provision machines on Equinix Metal you should consider using [one of the language libraries](https://www.packet.com/developers/libraries/) to code against. As an example, this is how you would launch a single Type 1 machine in a curl command. [API Documentation](https://www.packet.com/developers/api/).
 
 ```shell
 # Replace items in brackets (<EXAMPLE>) with the appropriate values.
@@ -38,7 +38,7 @@ Double quotes in the `<USERDATA>` value must be escaped such that the request bo
 ## iPXE booting
 
 If you need to run a Flatcar Container Linux image which is not available through the OS option in the API, you can boot via 'Custom iPXE'.
-This is the case for ARM64 images which are just published in the Alpha and Edge channels right now and not available via Packet's API.
+This is the case for ARM64 images which are just published in the Alpha and Edge channels right now and not available via Equinix Metal's API.
 
 Assuming you want to run boot an Alpha image via iPXE on a `c2.large.arm` machine, you have to provide this URL for 'Custom iPXE Settings':
 
@@ -46,15 +46,15 @@ Assuming you want to run boot an Alpha image via iPXE on a `c2.large.arm` machin
 https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_packet.ipxe
 ```
 
-Do not forget to provide an Ignition config with your SSH key because the PXE images don't have any OEM packages which could fetch the Packet project's SSH keys after booting.
+Do not forget to provide an Ignition config with your SSH key because the PXE images don't have any OEM packages which could fetch the Equinix Metal Project's SSH keys after booting.
 
 If not configured elsewise, iPXE booting will only done at the first boot because you are expected to install the operating system to the hard disk yourself.
 
 ## Container Linux Configs
 
-Flatcar Container Linux allows you to configure machine parameters, configure networking, launch systemd units on startup, and more via Container Linux Configs. These configs are then transpiled into Ignition configs and given to booting machines. Head over to the [docs to learn about the supported features][cl-configs]. Note that Packet doesn't allow an instance's userdata to be modified after the instance has been launched. This isn't a problem since Ignition only runs on the first boot.
+Flatcar Container Linux allows you to configure machine parameters, configure networking, launch systemd units on startup, and more via Container Linux Configs. These configs are then transpiled into Ignition configs and given to booting machines. Head over to the [docs to learn about the supported features][cl-configs]. Note that Equinix Metal doesn't allow an instance's userdata to be modified after the instance has been launched. This isn't a problem since Ignition only runs on the first boot.
 
-You can provide a raw Ignition config to Flatcar Container Linux via Packet's userdata field.
+You can provide a raw Ignition config to Flatcar Container Linux via Equinix Metal's userdata field.
 
 As an example, this config will configure and start etcd:
 

--- a/docs/clusters/creation/cluster-architectures.md
+++ b/docs/clusters/creation/cluster-architectures.md
@@ -89,7 +89,7 @@ Once you have a small cluster up and running, you can install a Kubernetes on th
 
 ### Configuring the machines
 
-For more information on getting started with this architecture, see the Flatcar Container Linux documentation on [supported platforms][flatcar-supported]. These include [Amazon EC2][flatcar-ec2], [Packet][flatcar-packet], [Azure][flatcar-azure], [Google Compute Platform][flatcar-gce], [bare metal iPXE][flatcar-bm], [Digital Ocean][flatcar-do], and many more community supported platforms.
+For more information on getting started with this architecture, see the Flatcar Container Linux documentation on [supported platforms][flatcar-supported]. These include [Amazon EC2][flatcar-ec2], [Equinix Metal][flatcar-equinix-metal], [Azure][flatcar-azure], [Google Compute Platform][flatcar-gce], [bare metal iPXE][flatcar-bm], [Digital Ocean][flatcar-do], and many more community supported platforms.
 
 Boot the desired number of machines with the same CL Config and discovery token. The CL Config specifies which services will be started on each machine.
 
@@ -210,7 +210,7 @@ networkd:
 [flatcar-supported]: https://docs.flatcar-linux.org/
 [flatcar-managed]: https://kinvolk.io/flatcar-container-linux/#kinvolk-update-service
 [flatcar-ec2]: https://docs.flatcar-linux.org/os/booting-on-ec2/
-[flatcar-packet]: https://docs.flatcar-linux.org/os/booting-on-packet/
+[flatcar-equinix-metal]: https://docs.flatcar-linux.org/os/booting-on-packet/
 [flatcar-azure]: https://docs.flatcar-linux.org/os/booting-on-azure/
 [flatcar-gce]: https://docs.flatcar-linux.org/os/booting-on-google-compute-engine/
 [flatcar-do]: https://docs.flatcar-linux.org/os/booting-on-digitalocean/

--- a/docs/community-platforms/_index.md
+++ b/docs/community-platforms/_index.md
@@ -10,7 +10,6 @@ The platforms and providers listed below each provide support and documentation 
 ## Cloud providers
 
 * [Exoscale][exoscale]
-* [Packet][packet]
 * [Rackspace Cloud][rackspace]
 * [Vultr VPS][vultr]
 
@@ -25,7 +24,6 @@ The platforms and providers listed below each provide support and documentation 
 
 [exoscale]: community-platforms/booting-on-exoscale
 [openstack]: community-platforms/booting-on-openstack
-[packet]: community-platforms/booting-on-packet
 [rackspace]: community-platforms/booting-on-rackspace
 [vultr]: community-platforms/booting-on-vultr
 [eucalyptus]: community-platforms/booting-on-eucalyptus

--- a/docs/quickstart/_index.md
+++ b/docs/quickstart/_index.md
@@ -4,7 +4,7 @@ linktitle: Quick start
 weight: 2
 ---
 
-If you don't have a Flatcar Container Linux machine running, check out the guides on [running Flatcar Container Linux][running-container-linux] on most cloud providers ([EC2][ec2-docs], [Azure][azure-docs], [GCE][gce-docs], [Packet][packet-docs]), virtualization platforms ([Vagrant][vagrant-docs], [VMware][vmware-docs], [VirtualBox][virtualbox-docs] [QEMU/KVM][qemu-docs]/[libVirt][libvirt-docs]) and bare metal servers ([PXE][pxe-docs], [iPXE][ipxe-docs], [ISO][iso-docs], [Installer][install-docs]). With any of these guides you will have machines up and running in a few minutes.
+If you don't have a Flatcar Container Linux machine running, check out the guides on [running Flatcar Container Linux][running-container-linux] on most cloud providers ([EC2][ec2-docs], [Azure][azure-docs], [GCE][gce-docs], [Equinix Metal][equinix-metal-docs]), virtualization platforms ([Vagrant][vagrant-docs], [VMware][vmware-docs], [VirtualBox][virtualbox-docs] [QEMU/KVM][qemu-docs]/[libVirt][libvirt-docs]) and bare metal servers ([PXE][pxe-docs], [iPXE][ipxe-docs], [ISO][iso-docs], [Installer][install-docs]). With any of these guides you will have machines up and running in a few minutes.
 
 It's highly recommended that you set up a cluster of at least 3 machines &mdash; it's not as much fun on a single machine. If you don't want to break the bank, [Vagrant][vagrant-docs] allows you to run an entire cluster on your laptop. For a cluster to be properly bootstrapped, you have to provide ideally an [Ignition config][ignition] (generated from a [Container Linux Config][cl-configs]), or possibly a cloud-config, via user-data, which is covered in each platform's guide.
 
@@ -124,7 +124,7 @@ docker run -i -t busybox /bin/sh
 [virtualbox-docs]: booting-on-virtualbox
 [qemu-docs]: booting-with-qemu
 [libvirt-docs]: booting-with-libvirt
-[packet-docs]: booting-on-packet
+[equinix-metal-docs]: booting-on-packet
 [pxe-docs]: booting-with-pxe
 [ipxe-docs]: booting-with-ipxe
 [iso-docs]: booting-with-iso

--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -12,4 +12,4 @@ This document tracks projects that integrate with Flatcar Container Linux. [Join
 - [Google Cloud Platform](https://cloud.google.com/compute/docs/images#os-compute-support): Google's cloud computing solution. Offers Flatcar Container Linux.
 - [Microsoft Azure](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/category/compute?subcategories=operating-systems&page=1#): Microsoft's cloud computing solution. Offers Flatcar Container Linux.
 - [DigitalOcean](https://www.digitalocean.com/products/linux-distribution/coreos/): An independent cloud computing solution. Offers Flatcar Container Linux.
-- [Packet](https://www.packet.net/promo/coreos/): A hosted bare metal solution. Offers Flatcar Container Linux.
+- [Equinix Metal](https://metal.equinix.com/): A hosted bare metal solution. Offers Flatcar Container Linux.

--- a/docs/terraform/_index.md
+++ b/docs/terraform/_index.md
@@ -1,0 +1,107 @@
+---
+title: Terraform
+description: >
+  Provision Flatcar Container Linux with an Ignition Configuration through Terraform
+weight: 40
+---
+
+Flatcar Container Linux fits well with Terraform for the principle of Immutable Infrastructure where you deploy a node and, instead of making changes via SSH, you destroy it and deploy a new node.
+The big advantages compared to other OSes are the inbuilt support for declarative configuration with Ignition on first boot and the automatic OS updates.
+
+Many cloud services allow to provide _User Data_ for a node in an extra attribute. Ignition will fetch the configuration from this place and apply it. No Terraform SSH provisioning commands are needed.
+
+## Terraform Providers for the different Cloud Services
+
+How to use the Terraform Providers of each cloud service is explained on the respective documentation page under [Cloud Providers](../cloud-providers/).
+
+## Changing the Ignition Configuration
+
+Changes to the User Data attribute should normally destroy the node and recreate it so that Ignition runs again on the first boot.
+However, this behavior depends on the Terraform provider for your cloud service.
+Some cloud services allow to update the attribute in-place without destroying the node but Ignition won't run again by default and even if you triggered it, you would have to be careful as this is not recommended (more on this at the end of this document).
+You can also tell Terraform not ignore attribute changes (set `ignore_changes`) and thus delay the change until you manually destroy the node and recreate it with Terraform.
+This is sometimes useful but may be a source of errors when you don't know that a node still runs an old configuration.
+
+To make the recreation of a node less disruptive, you can architect your setup to accept a node to exist twice at the same time and set `create_before_destroy` to let Terraform first create the replacement node and then destroy the old node.
+On AWS, it's also possible to use Auto Scaling Groups instead of directly operating on instances. In this case, to update the User Data you can replace the Auto Scaling Group, and the new one will take care of creating new nodes and the old one deletes the old ones.
+An advanced scheme of this on AWS can use Auto Scaling Groups instead of directly operating on instances, and to change the User Data you replace the Auto Scaling Group and the new one takes care of creating new nodes and the old one deletes the old ones.
+It is also advisable to separate the persistent data from the disposable nodes to external data volumes or to use a backup mechanism and inject the backup on the first boot.
+
+## Generating the Ignition Configuration within Terraform
+
+To convert the Container Linux Config in YAML to the final Igniton Config in JSON you don't need to run [`ct`](../container-linux-config-transpiler/) manually. Instead, you can directly do this within Terraform, through the [`terraform-ct-provider`](https://registry.terraform.io/providers/poseidon/ct/latest).
+Combined with the `template-provider` you can reference Terraform variables in the YAML template.
+
+An alternative is the [`terraform-ignition-provider`](https://www.terraform.io/docs/providers/ignition/index.html) that allows to assemble the Ignition Config from Terraform declarations.
+
+The following snippet demonstrates the use of the `terraform-ct-provider` and the `template-provider` to specify the User Data attribute on a Packet (now Equinix Metal) instance:
+
+```
+resource "packet_device" "machine" {
+  operating_system = "flatcar_stable"
+  user_data = data.ct_config.machine-ignition.rendered
+  [...]
+}
+
+data "ct_config" "machine-ignition" {
+  content = data.template_file.machine-cl-config.rendered
+}
+
+data "template_file" "machine-cl-config" {
+  template = file("${path.module}/machine.yaml.tmpl")
+  vars = { something = var.something }
+}
+```
+
+When using a template be careful to refer to the Terraform variables via `${variable}` while shell variables in scripts used at OS runtime need to be quoted like `$${variable}` or need to use the `$variable` syntax.
+
+## Updating the User Data in-place and rerunning Ignition instead of destroying nodes
+
+Sometimes you want to take the declarative approach of Terraform but can't accept that nodes are destroyed and recreated for configuration changes.
+This is the case for nodes that have a manual or slow bring-up process, much data that can't be moved easily, or where the IP address should not change.
+
+Ignition can be told to run again through `touch /boot/flatcar/first_boot` but it [won't clean up any old state](../ignition/boot-process/#reprovisioning).
+You have to reformat the root filesystem with Ignition to ensure that no old state is present.
+Persistent data should be stored on another partition.
+
+This Container Linux Config snippet takes care of that:
+
+```yaml
+filesystems:
+  - name: root
+    mount:
+      device: /dev/disk/by-label/ROOT
+      format: ext4
+      wipe_filesystem: true
+      label: ROOT
+```
+
+The final User Data needs to be stored on a place where modifications are allowed without destroying the node.
+A good option could be AWS S3 or other similar cloud storage solutions.
+The real User Data of the node is just an Ignition Config that references the external User Data:
+
+```
+{ "ignition": { "version": "2.1.0", "config": { "replace": { "source": "s3://..." } } } }
+```
+
+Under these conditions it is possible to run `touch /boot/flatcar/first_boot` on the node and trigger reboot for the new Ignition Config to take effect (assuming data in S3):
+
+```
+resource "null_resource" "reboot-when-ignition-changes" {
+  for_each = toset(var.machines)
+  # Triggered when the Ignition Config changes
+  triggers = {
+    ignition_config = data.ct_config.machine-ignitions[each.key].rendered
+  }
+  # Wait for the new Ignition config object to be ready before rebooting
+  depends_on = [aws_s3_bucket_object.object]
+  # Trigger running Ignition on the next reboot and reboot the instance (current limitation: also runs on the first provisioning)
+  provisioner "local-exec" {
+    command = "while ! ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null core@${packet_device.machine[each.key].access_public_ipv4} sudo touch /boot/flatcar/first_boot ; do sleep 1; done; while ! ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null core@${packet_device.machine[each.key].access_public_ipv4} sudo systemctl reboot; do sleep 1; done"
+  }
+}
+```
+
+## Examples
+
+You can find the full code for working examples in this [git repository](https://github.com/pothos/flatcar-terraform-examples).


### PR DESCRIPTION
A generic document describes how Terraform is used together with
Flatcar and Ignition. It covers the general principle. how to
generate the Ignition config and how to handle User Data changes.
An extra sections goes into the details of storing the User Data in
a remote location and rerunning Ignition in a safe way to circumvent
node recreation.
The provider-specific instructions for Terraform with Equinix Metal,
libvirt, and Hetzner are added to the cloud provider docs.
