### PR TITLE
Fix link to notes-for-distributors

### DIFF
--- a/docs/installing/bare-metal/booting-with-pxe.md
+++ b/docs/installing/bare-metal/booting-with-pxe.md
@@ -82,7 +82,7 @@ PXE booted machines cannot currently update themselves when new versions are rel
     <div class="tab-pane" id="alpha-create">
       <p>The Alpha channel closely tracks master and is released frequently. The newest versions of system libraries and utilities will be available for testing. The current version is Flatcar Container Linux {{< param alpha_channel >}}.</p>
       <p>In the config above you can see that a Kernel image and a initramfs file is needed. Download these two files into your tftp root.</p>
-      <p>The <code>flatcar_production_pxe.vmlinuz.sig</code> and <code>flatcar_production_pxe_image.cpio.gz.sig</code> files can be used to <a href="notes-for-distributors#importing-images">verify the downloaded files</a>.</p>
+      <p>The <code>flatcar_production_pxe.vmlinuz.sig</code> and <code>flatcar_production_pxe_image.cpio.gz.sig</code> files can be used to <a href="../../community-platforms/notes-for-distributors#importing-images">verify the downloaded files</a>.</p>
       <pre>
 cd /var/lib/tftpboot
 wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_pxe.vmlinuz
@@ -96,7 +96,7 @@ gpg --verify flatcar_production_pxe_image.cpio.gz.sig
     <div class="tab-pane" id="beta-create">
       <p>The Beta channel consists of promoted Alpha releases. The current version is Flatcar Container Linux {{< param beta_channel >}}.</p>
       <p>In the config above you can see that a Kernel image and a initramfs file is needed. Download these two files into your tftp root.</p>
-      <p>The <code>flatcar_production_pxe.vmlinuz.sig</code> and <code>flatcar_production_pxe_image.cpio.gz.sig</code> files can be used to <a href="notes-for-distributors#importing-images">verify the downloaded files</a>.</p>
+      <p>The <code>flatcar_production_pxe.vmlinuz.sig</code> and <code>flatcar_production_pxe_image.cpio.gz.sig</code> files can be used to <a href="../../community-platforms/notes-for-distributors#importing-images">verify the downloaded files</a>.</p>
       <pre>
 cd /var/lib/tftpboot
 wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_pxe.vmlinuz
@@ -110,7 +110,7 @@ gpg --verify flatcar_production_pxe_image.cpio.gz.sig
     <div class="tab-pane" id="edge-create">
       <p>The Edge channel includes bleeding-edge features with the newest versions of the Linux kernel, systemd and other core packages. Can be highly unstable. The current version is Flatcar Container Linux {{< param edge_channel >}}.</p>
       <p>In the config above you can see that a Kernel image and a initramfs file is needed. Download these two files into your tftp root.</p>
-      <p>The <code>flatcar_production_pxe.vmlinuz.sig</code> and <code>flatcar_production_pxe_image.cpio.gz.sig</code> files can be used to <a href="notes-for-distributors#importing-images">verify the downloaded files</a>.</p>
+      <p>The <code>flatcar_production_pxe.vmlinuz.sig</code> and <code>flatcar_production_pxe_image.cpio.gz.sig</code> files can be used to <a href="../../community-platforms/notes-for-distributors#importing-images">verify the downloaded files</a>.</p>
       <pre>
 cd /var/lib/tftpboot
 wget https://edge.release.flatcar-linux.net/amd64-usr/current/flatcar_production_pxe.vmlinuz
@@ -124,7 +124,7 @@ gpg --verify flatcar_production_pxe_image.cpio.gz.sig
     <div class="tab-pane active" id="stable-create">
       <p>The Stable channel should be used by production clusters. Versions of Flatcar Container Linux are battle-tested within the Beta and Alpha channels before being promoted. The current version is Flatcar Container Linux {{< param stable_channel >}}.</p>
       <p>In the config above you can see that a Kernel image and a initramfs file is needed. Download these two files into your tftp root.</p>
-      <p>The <code>flatcar_production_pxe.vmlinuz.sig</code> and <code>flatcar_production_pxe_image.cpio.gz.sig</code> files can be used to <a href="notes-for-distributors#importing-images">verify the downloaded files</a>.</p>
+      <p>The <code>flatcar_production_pxe.vmlinuz.sig</code> and <code>flatcar_production_pxe_image.cpio.gz.sig</code> files can be used to <a href="../../community-platforms/notes-for-distributors#importing-images">verify the downloaded files</a>.</p>
       <pre>
 cd /var/lib/tftpboot
 wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_pxe.vmlinuz


### PR DESCRIPTION
This was missed from my link-fix effort because it was hidden inside HTML code.

