### PR TITLE
provisioning/terraform: Use new repo location

### DIFF
--- a/docs/provisioning/terraform/_index.md
+++ b/docs/provisioning/terraform/_index.md
@@ -111,4 +111,4 @@ You can find the full code for working examples in this [git repository][example
 [terraform-ct-provider]: https://registry.terraform.io/providers/poseidon/ct/latest
 [terraform-ignition-provider]: https://www.terraform.io/docs/providers/ignition/index.html
 [boot-process]: ../ignition/boot-process/#reprovisioning
-[example-repo]: https://github.com/pothos/flatcar-terraform-examples
+[example-repo]: https://github.com/kinvolk/flatcar-terraform


### PR DESCRIPTION
The original repository was part of a talk presentation.
Now that we will add more examples, the repository was moved under
kinvolk/.

