### PR TITLE
Update the iscsi service name to reflect changes from update

### DIFF
--- a/docs/setup/storage/iscsi.md
+++ b/docs/setup/storage/iscsi.md
@@ -83,7 +83,7 @@ iscsiadm -m node --targetname=custom_target --login
 If you want to connect to iSCSI targets automatically at boot you first need to enable the systemd service:
 
 ```shell
-systemctl enable iscsid
+systemctl enable iscsi
 ```
 
 ## Automatic iSCSI configuration
@@ -106,7 +106,7 @@ discovery.sendtargets.auth.password = my_secret_password
 ```yaml
 systemd:
   units:
-    - name: iscsid.service
+    - name: iscsi.service
       enable: true
 storage:
   files:


### PR DESCRIPTION
# Update the iscsi service name to reflect changes from update

With the iscsi update, the systemd service that controls the
other services is `iscsi`

Signed-off-by: Sayan Chowdhury <sayan@kinvolk.io>