### PR TITLE
container-runtimes: Update section about using containerd for K8s

### DIFF
--- a/docs/container-runtimes/switching-from-docker-to-containerd-for-kubernetes.md
+++ b/docs/container-runtimes/switching-from-docker-to-containerd-for-kubernetes.md
@@ -1,7 +1,7 @@
 ---
 title: Switching from Docker to containerd for Kubernetes
 linktitle: Switching to containerd
-description: How to setup containerd to be the default or the only container runtime.
+description: How to setup containerd to be the default Kubernetes container runtime.
 weight: 20
 aliases:
     - ../os/switching-from-docker-to-containerd-for-kubernetes
@@ -21,40 +21,6 @@ And that it has access to the following binaries on the host file system and tha
 
 - `/run/torcx/unpack/docker/bin/containerd-shim-runc-v1`
 - `/run/torcx/unpack/docker/bin/containerd-shim-runc-v2`
-
-Finally, tell `kubelet` to use containerd by adding to it the following flags:
-- `--container-runtime=remote`
-- `--container-runtime-endpoint=unix:///run/docker/libcontainerd/docker-containerd.sock`
-
-## Running only `containerd` with CRI plugin enabled
-
-If you don't care about Docker compatibility and you only need `containerd` for Kubernetes, the following
-Container Linux Config allows that by using an empty containerd configuration instead of `/run/torcx/unpack/docker/usr/share/containerd/config.toml`:
-
-```yaml
-storage:
-  files:
-  - path: /etc/containerd/config.toml
-    filesystem: root
-    mode: 0600
-    contents:
-      inline: ""
-systemd:
-  units:
-  - name: containerd.service
-    enabled: true
-    dropins:
-    - name: 10-use-custom-config.conf
-      contents: |
-        [Service]
-        Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
-        ExecStart=
-        ExecStart=/usr/bin/env PATH=$${TORCX_BINDIR}:$${PATH} $${TORCX_BINDIR}/containerd --config $${CONTAINERD_CONFIG}
-```
-
-When running `kubelet`, make sure following directory is included in its `PATH`:
-
-- `/run/torcx/unpack/docker/bin/`
 
 Finally, tell `kubelet` to use containerd by adding to it the following flags:
 - `--container-runtime=remote`


### PR DESCRIPTION
The default socket location was changed (in a backwards-compatible way
through a symlink on the old location) and the section about using the
upstream defaults was confusing because it also involved breaking
Docker which should be solved by disabling the Docker service and
socket, not through a broken configuration.
