### PR TITLE
Fix path to the CL Config example file

### DIFF
--- a/docs/provisioning/config-transpiler/getting-started.md
+++ b/docs/provisioning/config-transpiler/getting-started.md
@@ -40,5 +40,5 @@ To see some examples for what else ct can do, head over to the [examples][3].
 
 [1]: ../config-transpiler/configuration
 [2]: https://github.com/kinvolk/ignition/blob/flatcar-master/doc/supported-platforms.md
-[3]: examples
+[3]: ../cl-config/examples
 [4]: https://github.com/kinvolk/container-linux-config-transpiler/releases


### PR DESCRIPTION
The example file was changed to a different directory but the link hadn't been fixed.

Fixes: kinvolk/Flatcar#344

Tested by running a local website and verifying that the link is now correct.