### PR TITLE
developer-guides: syntax fixes, drop "developer" from heading

### DIFF
--- a/docs/reference/developer-guides/_index.md
+++ b/docs/reference/developer-guides/_index.md
@@ -7,7 +7,7 @@ aliases:
 
 Most users will never have to build Flatcar Container Linux from source or modify it in any way. If you have a need to modify Flatcar Container Linux, we provide an SDK that allows you to build your own developer images. We also provide OEM functionality for cloud providers and other companies that must customize Flatcar Container Linux to run within their environment.
 
-* [Modifying Flatcar Container Linux][mod-cl]
+* [Guide to building customised Flatcar images][mod-cl]
 * [Building production images][production-images]
 * [Building custom kernel modules][kernel-modules]
 * [SDK tips and tricks][sdk-tips]

--- a/docs/reference/developer-guides/sdk-modifying-flatcar.md
+++ b/docs/reference/developer-guides/sdk-modifying-flatcar.md
@@ -1,5 +1,5 @@
 ---
-title: Developer guide to building customised Flatcar images
+title: Guide to building customised Flatcar images
 weight: 10
 aliases:
     - ../../os/sdk-modifying-flatcar
@@ -408,7 +408,7 @@ $ ./build_image --board=amd64-usr
 
 Next, we’ll look into changing the kernel configuration - e.g. for adding a kernel module or a core kernel feature not shipped with stock Flatcar. This will give you a low level deep dive into the Gentoo build system.
 
-Our first step is to set you all up with a pre-configured stock Flatcar Linux kernel to base your modifications on. The Flatcar Linux kernel build is split over multiple gentoo ebuild files which all reside in <code>[coreos-overlay/sys-kernel/](https://github.com/kinvolk/coreos-overlay/tree/main/sys-kernel):
+Our first step is to set you all up with a pre-configured stock Flatcar Linux kernel to base your modifications on. The Flatcar Linux kernel build is split over multiple gentoo ebuild files which all reside in <code>[coreos-overlay/sys-kernel/](https://github.com/kinvolk/coreos-overlay/tree/main/sys-kernel)</code>:
 
 *   `coreos-sources/` for pulling the kernel sources from git.kernel.org
 *   `coreos-kernel/` for building the main kernel (vmlinuz)
@@ -499,7 +499,7 @@ $ emerge-amd64-usr sys-kernel/coreos-modules
 $ ./build_image --board=amd64-usr
 $ ./image_to_vm.sh --from=../build/images/amd64-usr/latest --board=amd64-usr --format qemu
 $ ../build/images/amd64-usr/latest/flatcar_production_qemu.sh
-$ ssh core@localhost -p 2222`
+$ ssh core@localhost -p 2222
 ```
 
 ## Tips and tricks


### PR DESCRIPTION
This PR fixes a missing `</code>` tag and drops the "Developer" from the "Guide to building customised Flatcar images" title, since that document is already in the "Developer" section of the docs, removing some redundancy redundancy.