### PR TITLE
Fix broken links

### DIFF
--- a/docs/installing/bare-metal/booting-with-ipxe.md
+++ b/docs/installing/bare-metal/booting-with-ipxe.md
@@ -145,7 +145,7 @@ Now that you have a machine booted it is time to play around. Check out the [Fla
 [update-strategies]: ../../setup/releases/update-strategies
 [release-notes]: https://flatcar-linux.org/releases
 [pxe-installation]: booting-with-pxe#installation
-[pxe-oem]: booting-with-pxe#adding-a-custom-oem
+[pxe-custom-oem]: booting-with-pxe#adding-a-custom-oem
 [quickstart]: ../
 [doc-index]: ../../
 

--- a/docs/installing/bare-metal/booting-with-pxe.md
+++ b/docs/installing/bare-metal/booting-with-pxe.md
@@ -164,7 +164,7 @@ Since our upgrade process requires a disk, this image does not have the option t
 
 ## Installation
 
-Once booted it is possible to [install Flatcar Container Linux on a local disk][install-to-disk] or to just use local storage for the writable root filesystem while continuing to boot Flatcar Container Linux itself via PXE.
+Once booted it is possible to [install Flatcar Container Linux on a local disk][installing-to-disk] or to just use local storage for the writable root filesystem while continuing to boot Flatcar Container Linux itself via PXE.
 
 If you plan on using Docker we recommend using a local ext4 filesystem with overlayfs, however, btrfs is also available to use if needed.
 


### PR DESCRIPTION
# Fix broken links in docs

I found two broken links in the docs.
AFAIK, There's no other broken links (I tried to find same types of broken links using scripts)

- https://kinvolk.io/docs/flatcar-container-linux/latest/installing/bare-metal/booting-with-ipxe/#adding-a-custom-oem
- https://kinvolk.io/docs/flatcar-container-linux/latest/installing/bare-metal/booting-with-pxe/#installation

## How to use

Rebuilding pages may fix the problems.

## Testing done

I don't know how to build this, so I couldn't check whether this pr successfully fix the problems.