### PR TITLE
cgroup v2 docs

### DIFF
--- a/docs/container-runtimes/switching-to-unified-cgroups.md
+++ b/docs/container-runtimes/switching-to-unified-cgroups.md
@@ -19,7 +19,7 @@ migrate such nodes to cgroup v2, either remove the line or change it to
 `systemd.unified_cgroup_hierarchy=1`.
 
 Newly deployed nodes will default to cgroup v2.  To revert to cgroup v1 on such
-nodes, use the following ignition snippet:
+nodes, use the following Ignition snippet (here as CLC YAML to be transpiled to Ignition JSON):
 
 ```yaml
 storage:
@@ -38,7 +38,7 @@ storage:
           set linux_append="$linux_append systemd.unified_cgroup_hierarchy=0"
 ```
 
-A reboot is required before the snippet becomes active.
+However, this setting doesn't take effect on the first boot, and a reboot is required before the snippet becomes active.
 
 Beware that over time it is expected that upstream projects will drop support for cgroup v1.
 

--- a/docs/container-runtimes/switching-to-unified-cgroups.md
+++ b/docs/container-runtimes/switching-to-unified-cgroups.md
@@ -25,7 +25,7 @@ Flatcar version, a post update script does two things:
 To undo the changes performed by the post update script, execute the following commands as root (or using `sudo`):
 
 ```bash
-rm /etc/system/system/containerd.service.d/10-use-cgroupfs.conf
+rm /etc/systemd/system/containerd.service.d/10-use-cgroupfs.conf
 sed -i -e '/systemd.unified_cgroup_hierarchy=0/d' /usr/share/oem/grub.cfg
 sed -i -e '/systemd.legacy_systemd_cgroup_controller/d' /usr/share/oem/grub.cfg
 reboot
@@ -104,8 +104,9 @@ cgroupDriver: systemd
 
 ## Containerd
 
-If users choose the `containerd` runtime, they must ensure that `containerd`'s setting for `SystemdCgroup` is consistent with `kubelet` and `docker` settings. Flatcar enables `SystemdCgroup` by default for `containerd`. Users may change the setting to suit their deployment. To do that, follow the instructions on
-[how to customize containerd configuration](customizing-docker) and add the relevant lines to your `config.toml`:
+If users choose the `containerd` runtime, they must ensure that `containerd`'s setting for `SystemdCgroup` is consistent with `kubelet` and `docker` settings. Flatcar enables `SystemdCgroup` by default for `containerd`. Users may change the setting to suit their deployment.
+If you maintain your own containerd configuration or did follow the instructions on
+[how to customize containerd configuration](customizing-docker), you should add the relevant lines to your `config.toml`:
 ```toml
 # for version = 2 config files
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]

--- a/docs/container-runtimes/switching-to-unified-cgroups.md
+++ b/docs/container-runtimes/switching-to-unified-cgroups.md
@@ -1,0 +1,66 @@
+---
+title: Switching to Unified Cgroups
+linktitle: Switching to unified cgroups
+description: Overview of changes necessary to use unified cgroups with Kubernetes
+weight: 20
+aliases:
+---
+
+With the upgrade to Systemd v248, Flatcar Linux has migrated to the unified
+cgroup hierarchy (aka cgroup v2). Much of the container ecosystem has already
+moved to default to cgroup v2. Cgroup v2 also brings new and exciting features related to
+eBPF tracing.
+
+Flatcar nodes deployed prior to this change will be kept on cgroup v1 (legacy
+hierarchy) and will require manual migration. During an update from an older
+Flatcar version, a post installation script adds the kernel command line
+parameter `systemd.unified_cgroup_hierarchy=0` to `/usr/share/oem/grub.cfg`. To
+migrate such nodes to cgroup v2, either remove the line or change it to
+`systemd.unified_cgroup_hierarchy=1`.
+
+Newly deployed nodes will default to cgroup v2.  To revert to cgroup v1 on such
+nodes, use the following ignition snippet:
+
+```yaml
+storage:
+  filesystems:
+    - name: "OEM"
+      mount:
+        device: "/dev/disk/by-label/OEM"
+        format: "btrfs"
+  files:
+    - filesystem: "OEM"
+      path: "/grub.cfg"
+      mode: 0644
+      append: true
+      contents:
+        inline: |
+          set linux_append="$linux_append systemd.unified_cgroup_hierarchy=0"
+```
+
+A reboot is required before the snippet becomes active.
+
+Beware that over time it is expected that upstream projects will drop support for cgroup v1.
+
+The unified cgroup hierarchy is supported starting with Docker v20.10 and
+Kubernetes v1.19. Users that need to run older version will need to revert to
+cgroup v1, but are urged to find a migration path. Flatcar now ships with Docker
+v20.10, older versions can be deployed following the instructions on [running custom docker versions](use-a-custom-docker-or-containerd-version).
+
+Flatcar nodes that had Kubernetes deployed on them before the introduction of
+cgroup v2 should be careful when migrating. Depending on the deployment method,
+the `cgroupfs` cgroup driver may be hardcoded in the `kubelet` configuration.
+Cgroup v2 is only supported with the `systemd` cgroup driver. See [configuring a cgroup driver][kube-cgroup-docs] in the Kubernetes documentation for a discussion of cgroup drivers and how to migrate nodes. We recommend redeploying Kubernetes on fresh nodes instead of migrating inplace.
+
+The cgroup driver used by `kubelet` should be the same as the one used by `docker` daemon. `docker` defaults to `systemd` cgroup driver when started on a system running cgroup v2 and `cgroupfs` when running on a system with cgroup v1. The cgroup driver can be explicitly configured for `docker` by either creating/extending `/etc/docker/daemon.json`:
+```json
+{
+  "exec-opts": ["native.cgroupdriver=systemd"]
+}
+```
+or adding a `docker.service` drop-in at `/etc/systemd/system/docker.service.d/10-cgroup-v2.conf`:
+```ini
+[Service]
+Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=systemd"
+```
+[kube-cgroup-docs]: https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver/#migrating-to-the-systemd-driver

--- a/docs/container-runtimes/switching-to-unified-cgroups.md
+++ b/docs/container-runtimes/switching-to-unified-cgroups.md
@@ -27,6 +27,7 @@ To undo the changes performed by the post update script, execute the following c
 ```bash
 rm /etc/system/system/containerd.service.d/10-use-cgroupfs.conf
 sed -i -e '/systemd.unified_cgroup_hierarchy=0/d' /usr/share/oem/grub.cfg
+sed -i -e '/systemd.legacy_systemd_cgroup_controller/d' /usr/share/oem/grub.cfg
 reboot
 ```
 

--- a/docs/container-runtimes/switching-to-unified-cgroups.md
+++ b/docs/container-runtimes/switching-to-unified-cgroups.md
@@ -63,4 +63,21 @@ or adding a `docker.service` drop-in at `/etc/systemd/system/docker.service.d/10
 [Service]
 Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=systemd"
 ```
+
+# Kubernetes Container Runtimes
+
+When deploying Kubernetes through `kubeadm`, the default container runtime on Flatcar will be `dockershim`. In this setup, `kubelet` talks to `dockershim`, which talks to `docker`, which interfaces with `containerd`. The `SystemdCgroup` setting in `containerd`'s `config.toml` is ignored. `docker`'s cgroup driver and `kubelet` cgroup driver settings must match. Starting with Kubernetes v1.22, `kubeadm` will default to the `systemd` `cgroupDriver` setting if no setting is provided explicitly. Out of the box, Flatcar defaults are compatible with Docker and Kubernetes defaults - everything will use `systemd` cgroup driver.
+
+If users choose the `containerd` runtime, they must ensure that `containerd`'s support for `SystemdCgroups` is enabled. To do that, follow the instructions on
+[how to customize containerd configuration](customizing-docker) and add the following to `config.toml`:
+```toml
+[plugins.cri.containerd.runtimes.runc]
+  [plugins.cri.containerd.runtimes.runc.options]
+    SystemdCgroup = true
+ ```
+ Ensure `kubelet` uses the `systemd` cgroup driver.
+ 
+For a more detailed discussion of container runtimes, see the [Kubernetes documentation][kube-runtime-docs].
+
 [kube-cgroup-docs]: https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver/#migrating-to-the-systemd-driver
+[kube-runtime-docs]: https://kubernetes.io/docs/setup/production-environment/container-runtimes/


### PR DESCRIPTION
Add a page under `container runtimes` that explains the details of the cgroupv2 migration and impact.
