### PR TITLE
docs: Fix the Flatcar Container Linux version updating cgroupsv2

### DIFF
--- a/docs/container-runtimes/switching-to-unified-cgroups.md
+++ b/docs/container-runtimes/switching-to-unified-cgroups.md
@@ -6,7 +6,7 @@ weight: 20
 aliases:
 ---
 
-Beginning with Flatcar version 2970.0.0, Flatcar Linux has migrated to the unified
+Beginning with Flatcar version 2969.0.0, Flatcar Linux has migrated to the unified
 cgroup hierarchy (aka cgroup v2). Much of the container ecosystem has already
 moved to default to cgroup v2. Cgroup v2 brings exciting new features in
 areas such as eBPF and rootless containers.


### PR DESCRIPTION
The Alpha version to be released containing the cgroups v2 changes is `2969.0.0`. This commit updates the placeholder version we added earlier.

We will merge after we have released the Alpha version.