### PR TITLE
developer-guides: kernel-module: fix fetching of gpg signing key

### DIFF
--- a/docs/reference/developer-guides/kernel-modules.md
+++ b/docs/reference/developer-guides/kernel-modules.md
@@ -60,7 +60,8 @@ url="https://${GROUP:-stable}.release.flatcar-linux.net/${FLATCAR_RELEASE_BOARD}
 Download, decompress, and verify the development container image.
 
 ```shell
-gpg2 --keyserver pool.sks-keyservers.net --recv-keys F88CFEDEFF29A5B4D9523864E25D9AED0593B34A  # Fetch the buildbot key if necessary.
+curl -LO https://www.flatcar-linux.org/security/image-signing-key/Flatcar_Image_Signing_Key.asc
+gpg2 --import Flatcar_Image_Signing_Key.asc
 curl -L "${url}" |
     tee >(bzip2 -d > flatcar_developer_container.bin) |
     gpg2 --verify <(curl -Ls "${url}.sig") -


### PR DESCRIPTION
The old method doesn't work, and because Flatcar doesn't compile gpg with ssl support,
none of the other gpg servers will work. Instead fetch and import the key using curl.