### PR TITLE
Use correct image signing key URL

### DIFF
--- a/docs/installing/community-platforms/notes-for-distributors.md
+++ b/docs/installing/community-platforms/notes-for-distributors.md
@@ -30,7 +30,7 @@ The signing key is rotated annually. We will announce upcoming rotations of the 
 [beta-bucket]: https://beta.release.flatcar-linux.net/amd64-usr/
 [edge-bucket]: https://edge.release.flatcar-linux.net/amd64-usr/
 [stable-bucket]: https://stable.release.flatcar-linux.net/amd64-usr/
-[signing-key]: https://www.flatcar-linux.org/security/image-signing-key/
+[signing-key]: https://kinvolk.io/flatcar-container-linux/security/image-signing-key/
 [flatcar-user]: https://groups.google.com/forum/#!forum/flatcar-linux-user
 
 ## Image customization

--- a/docs/reference/developer-guides/kernel-modules.md
+++ b/docs/reference/developer-guides/kernel-modules.md
@@ -60,7 +60,7 @@ url="https://${GROUP:-stable}.release.flatcar-linux.net/${FLATCAR_RELEASE_BOARD}
 Download, decompress, and verify the development container image.
 
 ```shell
-curl -LO https://www.flatcar-linux.org/security/image-signing-key/Flatcar_Image_Signing_Key.asc
+curl -LO https://kinvolk.io/flatcar-container-linux/security/image-signing-key/Flatcar_Image_Signing_Key.asc
 gpg2 --import Flatcar_Image_Signing_Key.asc
 curl -L "${url}" |
     tee >(bzip2 -d > flatcar_developer_container.bin) |

--- a/docs/reference/developer-guides/sdk-modifying-flatcar.md
+++ b/docs/reference/developer-guides/sdk-modifying-flatcar.md
@@ -61,7 +61,7 @@ First, download the cork utility and verify it with the signature:
 ```shell
 $ curl -L -o cork https://github.com/kinvolk/mantle/releases/download/v0.16.0/cork-0.16.0-amd64
 $ curl -L -o cork.sig https://github.com/kinvolk/mantle/releases/download/v0.16.0/cork-0.16.0-amd64.sig
-$ curl -LO https://www.flatcar-linux.org/security/image-signing-key/Flatcar_Image_Signing_Key.asc
+$ curl -LO https://kinvolk.io/flatcar-container-linux/security/image-signing-key/Flatcar_Image_Signing_Key.asc
 $ gpg --import Flatcar_Image_Signing_Key.asc
 $ rm Flatcar_Image_Signing_Key.asc
 $ gpg --verify cork.sig cork


### PR DESCRIPTION
The old website has redirects in place for many parts but not for all,
and thus, the image signing key was outdated.
Use the right URL which users will also find on the website.

